### PR TITLE
Restore whitebox macro

### DIFF
--- a/src/core/adversaria.scala
+++ b/src/core/adversaria.scala
@@ -96,7 +96,7 @@ object Macros {
 
   /** delegates to the macro implementation method */
   def findMetadata[A <: StaticAnnotation: c.WeakTypeTag, T: c.WeakTypeTag]
-                  (c: blackbox.Context)
+                  (c: whitebox.Context)
                   : c.Tree =
     c.findMetadata(c.weakTypeOf[A], c.weakTypeOf[T])
 }


### PR DESCRIPTION
This was needed to allow the refined return type to be included.